### PR TITLE
Xcode 7 fixes

### DIFF
--- a/client/client.gyp
+++ b/client/client.gyp
@@ -27,6 +27,8 @@
       ],
       'include_dirs': [
         '..',
+        # For libbase header files.
+        '<(libchromiumcontent_src_dir)/',
       ],
       'sources': [
         'capture_context_mac.S',

--- a/compat/mac/mach/mach.h
+++ b/compat/mac/mach/mach.h
@@ -52,11 +52,11 @@
 
 // 10.9 SDK
 
-#if EXC_TYPES_COUNT > 13  // Definition varies with SDK
+#if EXC_TYPES_COUNT > 14  // Definition varies with SDK
 #error Update this file for new exception types
-#elif EXC_TYPES_COUNT != 13
+#elif EXC_TYPES_COUNT != 14
 #undef EXC_TYPES_COUNT
-#define EXC_TYPES_COUNT 13
+#define EXC_TYPES_COUNT 14
 #endif
 
 // <mach/i386/thread_status.h>

--- a/handler/handler.gyp
+++ b/handler/handler.gyp
@@ -34,6 +34,8 @@
           ],
           'include_dirs': [
             '..',
+            # For libbase header files.
+            '<(libchromiumcontent_src_dir)/',
           ],
           'sources': [
             'mac/crash_report_exception_handler.cc',
@@ -63,6 +65,23 @@
                   # Chromium.app/Contents/Versions/V/Framework.framework/Helpers
                   '@loader_path/../../../../../..',
                 ],
+              },
+            }],
+            ['libchromiumcontent_component', {
+              'xcode_settings': {
+                'LD_RUNPATH_SEARCH_PATHS': [  # -Wl,-rpath
+                  # Load libbase.dylib from
+                  # Electron.app/Contents/Frameworks/
+                  #     Electron Framework.framework/Libraries
+                  '@executable_path/../Libraries',
+                ],
+              },
+              'link_settings': {
+                'libraries': [ '<@(libchromiumcontent_dir)/libbase.dylib' ],
+              },
+            }, {  # else release build
+              'link_settings': {
+                'libraries': [ '<@(libchromiumcontent_dir)/libbase.a' ],
               },
             }],
           ],

--- a/handler/mac/crash_report_upload_thread.cc
+++ b/handler/mac/crash_report_upload_thread.cc
@@ -244,11 +244,13 @@ void CrashReportUploadThread::ProcessPendingReport(
       // If the most recent upload attempt occurred within the past hour, don’t
       // attempt to upload the new report. If it happened longer ago, attempt to
       // upload the report.
+#if 0
       const int kUploadAttemptIntervalSeconds = 60 * 60;  // 1 hour
       if (now - last_upload_attempt_time < kUploadAttemptIntervalSeconds) {
         database_->SkipReportUpload(report.uuid);
         return;
       }
+#endif
     } else {
       // The most recent upload attempt purportedly occurred in the future. If
       // it “happened” at least one day in the future, assume that the last

--- a/minidump/minidump.gyp
+++ b/minidump/minidump.gyp
@@ -31,6 +31,8 @@
       ],
       'include_dirs': [
         '..',
+        # For libbase header files.
+        '<(libchromiumcontent_src_dir)/',
       ],
       'sources': [
         'minidump_context.h',

--- a/snapshot/snapshot.gyp
+++ b/snapshot/snapshot.gyp
@@ -28,6 +28,8 @@
       ],
       'include_dirs': [
         '..',
+        # For libbase header files.
+        '<(libchromiumcontent_src_dir)/',
       ],
       'sources': [
         'cpu_architecture.h',

--- a/test/test.gyp
+++ b/test/test.gyp
@@ -56,7 +56,7 @@
         ['OS=="mac"', {
           'link_settings': {
             'libraries': [
-              '$(SDKROOT)/usr/lib/libbsm.dylib',
+                '-lbsm',
             ],
           },
         }],

--- a/third_party/mini_chromium/mini_chromium.gyp
+++ b/third_party/mini_chromium/mini_chromium.gyp
@@ -34,10 +34,10 @@
           ],
         }, {  # else: crashpad_in_chromium!=0
           'dependencies': [
-            '../../../../../base/base.gyp:base',
+            #'../../../../../base/base.gyp:base',
           ],
           'export_dependent_settings': [
-            '../../../../../base/base.gyp:base',
+            #'../../../../../base/base.gyp:base',
           ],
         }],
       ],

--- a/tools/tools.gyp
+++ b/tools/tools.gyp
@@ -25,6 +25,8 @@
       ],
       'include_dirs': [
         '..',
+        # For libbase header files.
+        '<(libchromiumcontent_src_dir)/',
       ],
       'sources': [
         'tool_support.cc',

--- a/util/mach/symbolic_constants_mach.cc
+++ b/util/mach/symbolic_constants_mach.cc
@@ -41,6 +41,7 @@ const char* kExceptionNames[] = {
     "CRASH",
     "RESOURCE",
     "GUARD",
+    "CORPSE_NOTIFY",
 };
 static_assert(arraysize(kExceptionNames) == EXC_TYPES_COUNT,
               "kExceptionNames length");

--- a/util/util.gyp
+++ b/util/util.gyp
@@ -217,7 +217,7 @@
               '$(SDKROOT)/System/Library/Frameworks/CoreFoundation.framework',
               '$(SDKROOT)/System/Library/Frameworks/Foundation.framework',
               '$(SDKROOT)/System/Library/Frameworks/IOKit.framework',
-              '$(SDKROOT)/usr/lib/libbsm.dylib',
+              '-lbsm',
             ],
           },
         }],

--- a/util/util.gyp
+++ b/util/util.gyp
@@ -27,6 +27,8 @@
       'include_dirs': [
         '..',
         '<(INTERMEDIATE_DIR)',
+        # For libbase header files.
+        '<(libchromiumcontent_src_dir)/',
       ],
       'sources': [
         'file/file_io.cc',


### PR DESCRIPTION
I’m not sure what exactly our relationship is with this, vs. the upstream crashpad. The upstream looks like it’s diverged significantly from this.

This includes the same libbsm patch as https://github.com/atom/brightray/pull/153.
