### PR TITLE
Handle everything not in [200, 300) as error.

### DIFF
--- a/util/net/http_transport_libcurl.cc
+++ b/util/net/http_transport_libcurl.cc
@@ -338,7 +338,7 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
     return false;
   }
 
-  if (status != 200) {
+  if (status < 200 || status >= 300) {
     LOG(ERROR) << base::StringPrintf("HTTP status %ld", status);
     return false;
   }

--- a/util/net/http_transport_mac.mm
+++ b/util/net/http_transport_mac.mm
@@ -293,7 +293,7 @@ bool HTTPTransportMac::ExecuteSynchronously(std::string* response_body) {
       return false;
     }
     NSInteger http_status = [http_response statusCode];
-    if (http_status != 200) {
+    if (http_status < 200 || http_status >= 300) {
       LOG(ERROR) << base::StringPrintf("HTTP status %ld",
                                        implicit_cast<long>(http_status));
       return false;

--- a/util/net/http_transport_win.cc
+++ b/util/net/http_transport_win.cc
@@ -369,7 +369,7 @@ bool HTTPTransportWin::ExecuteSynchronously(std::string* response_body) {
     return false;
   }
 
-  if (status_code != 200) {
+  if (status_code < 200 || status_code >= 300) {
     LOG(ERROR) << base::StringPrintf("HTTP status %d", status_code);
     return false;
   }


### PR DESCRIPTION
We discovered that some crash servers might return 202 or different 2xx codes. For example we are using HockeyApp to upload crashes and their response is 202.

This pull request is intended to make the handling of error codes more flexible.

Maybe will create one pull request for Chromium so we have it in both places.